### PR TITLE
Fix undefined res.ext for non native parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function parse(fp) {
   } else {
     var ext = path.extname(fp);
     res.name = path.basename(fp, ext);
-    res.basename = res.name + res.ext;
+    res.basename = res.name + ext;
     res.extname = path.extname(fp);
     res.dirname = path.dirname(fp);
     res.root = '';


### PR DESCRIPTION
For non native `path.parse` (node <= 0.10) `basename` resolve to `whateverundefined` du to `res.ext` being undefined.



